### PR TITLE
fix: Projectsページの優先度ソートを「正→未設定→負」の順に修正

### DIFF
--- a/src/lib/api/getProjects.ts
+++ b/src/lib/api/getProjects.ts
@@ -39,5 +39,14 @@ export const getProjects = async (): Promise<Project[]> => {
     hasNext = offset < totalCount;
   }
 
+  // priorityが設定されていないプロジェクトを優先度0として扱う
+  allProjects.forEach((project) => {
+    if (project.priority === undefined) {
+      project.priority = 0; // デフォルトの優先度を0に設定
+    }
+  });
+  // 優先度でソート
+  allProjects.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  
   return allProjects;
 };


### PR DESCRIPTION
## 🧩 関連するIssue / Related Issues

<!-- 例: close #12, fix #34 -->
close #28 


## 🔍 概要 / Summary

<!-- このPRの目的や背景など、ざっくりとした内容を記載してください -->
優先度に負の値を設定した場合に未設定の項目より後に表示されるよう調整する

## 🛠 変更内容 / Changes

<!-- 主な変更点を簡潔に箇条書きで -->
- 優先度未設定のコンテンツは優先度を0に設定
- 優先度0の設定後に再度ソート


## 📸 スクリーンショット / Screenshot（UI変更がある場合）




## ✅ チェックリスト / Checklist

- [x] Lintエラーが解消されていること
- [x] 対象Issueがあれば、紐付けていること


## 📚 備考 / Notes

<!-- 実装の補足、今後の対応予定、レビュー観点など -->
